### PR TITLE
Execute workflow by name

### DIFF
--- a/lumy_middleware/__init__.py
+++ b/lumy_middleware/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 version = __version__

--- a/lumy_middleware/context/kiara/app_context.py
+++ b/lumy_middleware/context/kiara/app_context.py
@@ -72,17 +72,17 @@ def get_pipeline_input_id(ids: List[str]) -> Optional[str]:
 class KiaraAppContext(AppContext, BatchController):
     _current_workflow: KiaraWorkflow
     _data_registry: DataRegistry
+    _kiara = Kiara.instance()
 
     def load_workflow(self, workflow_file_or_name: Union[Path, str]) -> None:
         '''
         AppContext
         '''
-        kiara: Kiara = Kiara.instance()
 
-        self._current_workflow = kiara.create_workflow(
+        self._current_workflow = self._kiara.create_workflow(
             str(workflow_file_or_name), controller=self)
 
-        self._data_registry = KiaraDataRegistry(kiara)
+        self._data_registry = KiaraDataRegistry(self._kiara)
         # self._data_registry = MockDataRegistry()
 
         # TODO: access the pipeline here because it is lazily created

--- a/lumy_middleware/context/kiara/dataregistry.py
+++ b/lumy_middleware/context/kiara/dataregistry.py
@@ -103,7 +103,10 @@ class KiaraDataRegistry(DataRegistry[Value]):
         TODO: Filtering implementation is not efficient at all.
         Waiting for better filtering support in Kiara.
         '''
-        ids = list(self._kiara.data_store.value_ids)
+        # ids = list(self._kiara.data_store.value_ids)
+        # TODO: Not sure if we should use value_ids or aliases.values
+        # kiara CLI uses aliases that excludes duplicates
+        ids = list(self._kiara.data_store.aliases.values())
 
         for k, v in kwargs.items():
             filters = FiltersMap.get(k, None)

--- a/lumy_middleware/jupyter/message_handlers/workflow.py
+++ b/lumy_middleware/jupyter/message_handlers/workflow.py
@@ -1,7 +1,11 @@
 import logging
 
+from kiara.kiara import Kiara
 from lumy_middleware.jupyter.base import MessageHandler
 from lumy_middleware.types import MsgWorkflowUpdated
+from lumy_middleware.types.generated import (MsgWorkflowExecute,
+                                             MsgWorkflowExecutionResult,
+                                             Status)
 from lumy_middleware.utils.dataclasses import to_dict
 
 logger = logging.getLogger(__name__)
@@ -17,3 +21,51 @@ class WorkflowMessageHandler(MessageHandler):
             None if self._context.current_workflow_structure is None
             else to_dict(self._context.current_workflow_structure)
         ))
+
+    def _handle_Execute(self, msg: MsgWorkflowExecute):
+        # TODO: This can be better encapsulated into context
+        kiara: Kiara = getattr(self.context, '_kiara', None)
+        if kiara is None:
+            logger.warn('No kiara is available')
+            response = MsgWorkflowExecutionResult(
+                request_id=msg.request_id,
+                status=Status.ERROR,
+                error_message='No kiara is available'
+            )
+        else:
+            try:
+                workflow = kiara.create_workflow(
+                    msg.module_name, workflow_id=msg.workflow_id)
+                inputs = msg.inputs or {}
+                workflow.inputs.set_values(**inputs)
+
+                outputs_ids = {}
+
+                if msg.save:
+                    for field, value \
+                            in workflow.outputs.items():  # type: ignore
+                        value_type = value.type_obj
+                        save_config = value_type.save_config()
+
+                        # values without 'save_config' cannot be saved
+                        # https://github.com/DHARPA-Project/kiara/blob/4263687ebd1c0749a719fb489f004bce46935780/src/kiara/data/persistence.py#L83
+                        if save_config is not None:
+                            value_id = value.save()
+                            outputs_ids[field] = value_id
+
+                response = MsgWorkflowExecutionResult(
+                    request_id=msg.request_id,
+                    status=Status.OK,
+                    result={
+                        'outputs': outputs_ids
+                    }
+                )
+            except Exception as e:
+                logger.exception(f'Could not execute workflow: {str(e)}')
+                response = MsgWorkflowExecutionResult(
+                    request_id=msg.request_id,
+                    status=Status.ERROR,
+                    error_message=str(e)
+                )
+
+        self.publisher.publish(response)

--- a/lumy_middleware/types/generated.py
+++ b/lumy_middleware/types/generated.py
@@ -527,6 +527,48 @@ class MsgParametersSnapshots:
 
 
 @dataclass
+class MsgWorkflowExecute:
+    """Target: "workflow"
+    Message type: "Execute"
+    
+    Execute a Kiara workflow.
+    """
+    """Name of the module or pipeline workflow to execute."""
+    module_name: str
+    """A unique ID representing this request. It's needed solely to correlate this request to
+    the response in pub/sub.
+    """
+    request_id: str
+    """Input values of the workflow."""
+    inputs: Optional[Dict[str, Any]] = None
+    """If true, the outputs of the workflow will be saved in the data repository."""
+    save: Optional[bool] = None
+    """ID of the workflow execution"""
+    workflow_id: Optional[str] = None
+
+
+class Status(Enum):
+    ERROR = "error"
+    OK = "ok"
+
+
+@dataclass
+class MsgWorkflowExecutionResult:
+    """Target: "workflow"
+    Message type: "ExecutionResult"
+    
+    Result of an execution of a Kiara workflow.
+    """
+    """A unique ID representing the execution request. Set in `Execute` message."""
+    request_id: str
+    status: Status
+    """Error message when status is 'error'."""
+    error_message: Optional[str] = None
+    """Result of the execution. Structure depends on the workflow. TBD."""
+    result: Optional[Dict[str, Any]] = None
+
+
+@dataclass
 class MsgWorkflowUpdated:
     """Target: "workflow"
     Message type: "Updated"


### PR DESCRIPTION
This is currently needed to support migration from mock data registry to Kiara data registry. We give the user a simple interface to execute one of the onboarding Kiara workflows.