### PR TITLE
Using typing types

### DIFF
--- a/lumy_middleware/__init__.py
+++ b/lumy_middleware/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.3.5'
+__version__ = '0.3.6'
 version = __version__

--- a/lumy_middleware/context/dataregistry.py
+++ b/lumy_middleware/context/dataregistry.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Iterable, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union
 
 
 class QueryOperator(ABC):
@@ -18,9 +18,9 @@ class Eq(QueryOperator, Generic[T]):
 
 
 class IsIn(QueryOperator, Generic[T]):
-    values: list[T]
+    values: List[T]
 
-    def __init__(self, values: list[T]):
+    def __init__(self, values: List[T]):
         self.values = values
 
 
@@ -35,14 +35,14 @@ class DataRegistryItem:
     id: str
     label: str
     type: str
-    metadata: dict[str, Any]
+    metadata: Dict[str, Any]
 
     def __init__(
         self,
         id: str,
         label: str,
         type: str,
-        metadata: dict[str, Any] = {}
+        metadata: Dict[str, Any] = {}
     ):
         self.id = id
         self.label = label
@@ -71,7 +71,7 @@ class Batch(ABC):
     def __getitem__(
             self,
             key
-    ) -> Union[DataRegistryItem, list[DataRegistryItem]]:
+    ) -> Union[DataRegistryItem, List[DataRegistryItem]]:
         if isinstance(key, slice):
             assert key.step is None or key.step == 1, \
                 f'Step other than 1 is not supported, it is {key.step}'

--- a/lumy_middleware/context/kiara/app_context.py
+++ b/lumy_middleware/context/kiara/app_context.py
@@ -86,9 +86,9 @@ class ReverseMappingItem:
 
 @dataclass
 class ReverseIoMappings:
-    inputs: dict[str, list[ReverseMappingItem]] = field(
+    inputs: Dict[str, List[ReverseMappingItem]] = field(
         default_factory=lambda: defaultdict(list))
-    outputs: dict[str, list[ReverseMappingItem]] = field(
+    outputs: Dict[str, List[ReverseMappingItem]] = field(
         default_factory=lambda: defaultdict(list))
 
 
@@ -97,8 +97,8 @@ PipelineId = '__pipeline__'
 
 def build_reverse_io_mappings(
     workflow: LumyWorkflow
-) -> dict[str, ReverseIoMappings]:
-    lookup: dict[str, ReverseIoMappings] = defaultdict(ReverseIoMappings)
+) -> Dict[str, ReverseIoMappings]:
+    lookup: Dict[str, ReverseIoMappings] = defaultdict(ReverseIoMappings)
 
     for page in (workflow.ui.pages or []):
         mapping = page.mapping
@@ -123,7 +123,7 @@ class KiaraAppContext(AppContext, BatchController):
     _data_registry: DataRegistry
     _kiara = Kiara.instance()
     # kiara workflow step Id -> mappings
-    _reverse_io_mappings: dict[str, ReverseIoMappings]
+    _reverse_io_mappings: Dict[str, ReverseIoMappings]
 
     def load_workflow(
         self,
@@ -274,7 +274,7 @@ class KiaraAppContext(AppContext, BatchController):
         '''
         super().step_inputs_changed(event)
 
-        page_id_to_input_ids: dict[str, list[str]] = defaultdict(list)
+        page_id_to_input_ids: Dict[str, List[str]] = defaultdict(list)
 
         for step_id, input_ids in event.updated_step_inputs.items():
             for input_id in input_ids:
@@ -292,7 +292,7 @@ class KiaraAppContext(AppContext, BatchController):
         PipelineController
         '''
 
-        page_id_to_output_ids: dict[str, list[str]] = defaultdict(list)
+        page_id_to_output_ids: Dict[str, List[str]] = defaultdict(list)
 
         for step_id, output_ids in event.updated_step_outputs.items():
             for output_id in output_ids:
@@ -360,7 +360,7 @@ class KiaraAppContext(AppContext, BatchController):
         step_id: Optional[str],
         io_id: str,
         is_input: bool
-    ) -> list[Tuple[str, str]]:
+    ) -> List[Tuple[str, str]]:
         if self._reverse_io_mappings is None:
             return []
 
@@ -375,7 +375,7 @@ class KiaraAppContext(AppContext, BatchController):
         self,
         step_id: Optional[str],
         input_id: str
-    ) -> list[Tuple[str, str]]:
+    ) -> List[Tuple[str, str]]:
         return self._get_page_io_ids_for_workflow_io_id(
             step_id, input_id, True)
 
@@ -383,6 +383,6 @@ class KiaraAppContext(AppContext, BatchController):
         self,
         step_id: Optional[str],
         output_id: str
-    ) -> list[Tuple[str, str]]:
+    ) -> List[Tuple[str, str]]:
         return self._get_page_io_ids_for_workflow_io_id(
             step_id, output_id, False)

--- a/lumy_middleware/context/kiara/dataregistry.py
+++ b/lumy_middleware/context/kiara/dataregistry.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Iterable, Optional, Type, cast
+from typing import Any, Callable, Dict, Iterable, List, Optional, Type, cast
 
 from lumy_middleware.context.dataregistry import (Batch, DataRegistry,
                                                   DataRegistryItem, Eq, IsIn,
@@ -34,7 +34,7 @@ def substring_fn(field: str):
     return fn
 
 
-FiltersMap: dict[str, dict[Type[QueryOperator], FilterFn]] = {
+FiltersMap: Dict[str, Dict[Type[QueryOperator], FilterFn]] = {
     'id': {
         Eq: eq_fn('id'),
         IsIn: isin_fn('id'),
@@ -68,15 +68,15 @@ def as_item(id: str, kiara: Kiara) -> DataRegistryItem:
         id=value.id,
         label=get_value_label(value),
         type=value.type_name,
-        metadata=cast(dict[str, Any], value.get_metadata())
+        metadata=cast(Dict[str, Any], value.get_metadata())
     )
 
 
 class KiaraBatch(Batch):
     _kiara: Kiara
-    _ids: list[str]
+    _ids: List[str]
 
-    def __init__(self, ids: list[str], kiara: Kiara):
+    def __init__(self, ids: List[str], kiara: Kiara):
         self._ids = ids
         self._kiara = kiara
 

--- a/lumy_middleware/dev/data_registry/mock.py
+++ b/lumy_middleware/dev/data_registry/mock.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Optional, Type
+from typing import Any, Callable, Dict, Iterable, List, Optional, Type
 from uuid import uuid4
 
 import pandas as pd
@@ -49,9 +49,9 @@ def to_item(f: Path):
 
 
 class MockBatch(Batch):
-    items: list[DataRegistryItem]
+    items: List[DataRegistryItem]
 
-    def __init__(self, items: list[DataRegistryItem]):
+    def __init__(self, items: List[DataRegistryItem]):
         self.items = items
 
     def slice(self,
@@ -84,7 +84,7 @@ def substring_fn(field: str):
     return fn
 
 
-FiltersMap: dict[str, dict[Type[QueryOperator], FilterFn]] = {
+FiltersMap: Dict[str, Dict[Type[QueryOperator], FilterFn]] = {
     'id': {
         Eq: eq_fn('id'),
         IsIn: isin_fn('id'),
@@ -108,7 +108,7 @@ class MockValue(Value):
                  id: str,
                  type: str,
                  data: Any,
-                 metadata: dict[str, dict[str, Any]] = {}):
+                 metadata: Dict[str, Dict[str, Any]] = {}):
         self._data = data
         super().__init__(
             id=id,
@@ -130,7 +130,7 @@ class MockDataRegistry(DataRegistry[MockValue]):
     _files_path: Path
     _file_lookup: Dict[str, Path] = {}
 
-    _items: list[DataRegistryItem]
+    _items: List[DataRegistryItem]
 
     def __init__(self, files_location=DefaultFilesPath):
         self._files_path = files_location

--- a/lumy_middleware/jupyter/message_handlers/data_repository.py
+++ b/lumy_middleware/jupyter/message_handlers/data_repository.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, cast
+from typing import Any, Dict, List, cast
 
 import pyarrow as pa
 from kiara.data.values import Value
@@ -18,11 +18,11 @@ from lumy_middleware.utils.dataclasses import to_dict
 logger = logging.getLogger(__name__)
 
 
-def get_column_names(metadata: dict[str, Any]) -> list[str]:
+def get_column_names(metadata: Dict[str, Any]) -> List[str]:
     return metadata.get('table', {}).get('column_names', [])
 
 
-def get_column_types(metadata: dict[str, Any]) -> list[str]:
+def get_column_types(metadata: Dict[str, Any]) -> List[str]:
     columns = get_column_names(metadata)
     schema = metadata.get('table', {}).get('schema', {})
     return [
@@ -31,7 +31,7 @@ def get_column_types(metadata: dict[str, Any]) -> list[str]:
     ]
 
 
-def as_table(items: list[DataRegistryItem]) -> pa.Table:
+def as_table(items: List[DataRegistryItem]) -> pa.Table:
     '''
     TODO: This is a basic implementation. Need to allow
     the method caller to select which metadata columns
@@ -60,7 +60,7 @@ class DataRepositoryHandler(MessageHandler):
         offset = msg.filter.offset or 0
         page_size = msg.filter.page_size or 5
 
-        filtered_items: list[DataRegistryItem] = batch[offset:offset+page_size]
+        filtered_items: List[DataRegistryItem] = batch[offset:offset+page_size]
         filtered_items_table = as_table(filtered_items)
 
         serialized_filtered_items, _ = serialize(filtered_items_table)


### PR DESCRIPTION
using types from `typing` instead of python type keywords which are not supported in the version Lumy shipped with