### PR TITLE
Pinned network_analysis kiara module to version 0.1.0

### DIFF
--- a/lumy_middleware/workflows/resources/networkAnalysisWorkflow.yml
+++ b/lumy_middleware/workflows/resources/networkAnalysisWorkflow.yml
@@ -4,7 +4,7 @@ processing:
   dependencies:
     pythonPackages:
       - name: lumy-middleware>=0.3.8
-      - name: kiara_modules.network_analysis>=0.1.0
+      - name: kiara_modules.network_analysis==0.1.0
   data:
     transformations:
       - sourceType: network_graph


### PR DESCRIPTION
Current Lumy version works with kiara version `0.1.0`.  The latest version of `network_analysis` module requires kiara version higher than `0.1.0`. This PR pins the version of `network_analysis` to `0.1.0` to avoid accidental upgrades of kiara.